### PR TITLE
calculateStandardDeviation bugfix

### DIFF
--- a/lib/bp.js
+++ b/lib/bp.js
@@ -64,7 +64,7 @@ bp.Statistics.calculateStandardDeviation = function(sample, mean) {
   sample.forEach(function(x) {
     deviation += Math.pow(x - mean, 2);
   });
-  deviation = deviation / (sample.length -1);
+  deviation = deviation / sample.length;
   deviation = Math.sqrt(deviation);
   return deviation;
 };


### PR DESCRIPTION
Following the standard deviation formulas, the deviation will be divided by the size of sample

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/benchpress/14)

<!-- Reviewable:end -->
