### PR TITLE
perf(benchpress) improve to function collectExpressionInputs

### DIFF
--- a/benchmarks/largetable/angular.js
+++ b/benchmarks/largetable/angular.js
@@ -12420,19 +12420,11 @@ function $ParseProvider() {
           return addInterceptor(noop, interceptorFn);
       }
     };
-
-    function collectExpressionInputs(inputs, list) {
-      for (var i = 0, ii = inputs.length; i < ii; i++) {
-        var input = inputs[i];
-        if (!input.constant) {
-          if (input.inputs) {
-            collectExpressionInputs(input.inputs, list);
-          } else if (list.indexOf(input) === -1) { // TODO(perf) can we do better?
-            list.push(input);
-          }
-        }
+    
+    function collectExpressionInputsls(inputs, list){
+      for(let value of inputs => !value.constant){
+        list.push(value);
       }
-
       return list;
     }
 


### PR DESCRIPTION
The function "collectExpressionInputs" was doing an unnecessary recursive call. 
there was a label "//TODO (perf) Can we do it better?", so here is an option :).
I hope it works, Greetings!.

